### PR TITLE
GetMute und GetVolume waren fehlerhaft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# ===============
+# PHPStorm
+# ===============
+.idea

--- a/PTV/module.php
+++ b/PTV/module.php
@@ -63,7 +63,7 @@ class PTV extends IPSModule
         $this->SetState(false);
     }
 
-    public function SetState(bool $on = true)
+    public function SetState(bool $on)
     {
         if ($this->GetValue('STATE') != $on) {
             $this->SendKey('NRC_POWER-ONOFF');
@@ -116,7 +116,7 @@ class PTV extends IPSModule
         }
     }
 
-    public function getVolume()
+    public function GetVolume()
     {
         return $this->SoapRequest(
             'dmr/control_0',
@@ -127,7 +127,7 @@ class PTV extends IPSModule
         );
     }
 
-    public function getMute()
+    public function GetMute()
     {
         return $this->SoapRequest(
             'dmr/control_0',
@@ -138,7 +138,7 @@ class PTV extends IPSModule
         );
     }
 
-    public function setMute(bool $enable = false)
+    public function SetMute(bool $enable)
     {
         $data = ($enable) ? '1' : '0';
         return $this->SoapRequest(
@@ -150,7 +150,7 @@ class PTV extends IPSModule
         );
     }
 
-    public function setVolume(integer $volume = 0)
+    public function SetVolume(integer $volume)
     {
         $volume = intval($volume);
         if ($volume > 100 || $volume < 0)

--- a/PTV/module.php
+++ b/PTV/module.php
@@ -107,7 +107,7 @@ class PTV extends IPSModule
         } else {
             $xml = simplexml_load_string($data);
             if ($xml === false) {
-                return false;
+                trigger_error('SoapRequest failed (action = '.$action . ')');
             }
             $ns = $xml->getNamespaces(true);
             $soap = $xml->children($ns['s']);
@@ -118,23 +118,23 @@ class PTV extends IPSModule
 
     public function GetVolume()
     {
-        return $this->SoapRequest(
+        return (int) $this->SoapRequest(
             'dmr/control_0',
             'schemas-upnp-org:service:RenderingControl:1',
             'GetVolume',
             array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
-                  'returnXml' => true)
+                  'returnXml' => false)
         );
     }
 
     public function GetMute()
     {
-        return $this->SoapRequest(
+        return (boolean) $this->SoapRequest(
             'dmr/control_0',
             'schemas-upnp-org:service:RenderingControl:1',
             'GetMute',
             array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
-                  'returnXml' => true)
+                  'returnXml' => false)
         );
     }
 

--- a/PTV/module.php
+++ b/PTV/module.php
@@ -138,7 +138,7 @@ class PTV extends IPSModule
         );
     }
 
-    protected function setMute($enable = false)
+    public function setMute(bool $enable = false)
     {
         $data = ($enable) ? '1' : '0';
         return $this->SoapRequest(
@@ -150,7 +150,7 @@ class PTV extends IPSModule
         );
     }
 
-    protected function setVolume($volume = '0')
+    public function setVolume(integer $volume = 0)
     {
         $volume = intval($volume);
         if ($volume > 100 || $volume < 0)

--- a/PTV/module.php
+++ b/PTV/module.php
@@ -122,7 +122,8 @@ class PTV extends IPSModule
             'dmr/control_0',
             'schemas-upnp-org:service:RenderingControl:1',
             'GetVolume',
-            array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>')
+            array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
+                  'returnXml' => true)
         );
     }
 
@@ -132,7 +133,8 @@ class PTV extends IPSModule
             'dmr/control_0',
             'schemas-upnp-org:service:RenderingControl:1',
             'GetMute',
-            array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>')
+            array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
+                  'returnXml' => true)
         );
     }
 
@@ -143,7 +145,8 @@ class PTV extends IPSModule
             'dmr/control_0',
             'schemas-upnp-org:service:RenderingControl:1',
             'SetMute',
-            array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredMute>'.$data.'</DesiredMute>')
+            array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredMute>'.$data.'</DesiredMute>',
+                  'returnXml' => true)
         );
     }
 
@@ -158,7 +161,8 @@ class PTV extends IPSModule
             'dmr/control_0',
             'schemas-upnp-org:service:RenderingControl:1',
             'SetVolume',
-            array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>'.$volume.'</DesiredVolume>', 'returnXml' => true)
+            array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>'.$volume.'</DesiredVolume>',
+                  'returnXml' => true)
         );
     }
 

--- a/PTV/module.php
+++ b/PTV/module.php
@@ -123,7 +123,7 @@ class PTV extends IPSModule
             'schemas-upnp-org:service:RenderingControl:1',
             'GetVolume',
             array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
-                  'returnXml' => true)
+                  'returnXml' => false)
         );
     }
 
@@ -134,7 +134,7 @@ class PTV extends IPSModule
             'schemas-upnp-org:service:RenderingControl:1',
             'GetMute',
             array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
-                  'returnXml' => true)
+                  'returnXml' => false)
         );
     }
 

--- a/PTV/module.php
+++ b/PTV/module.php
@@ -123,7 +123,7 @@ class PTV extends IPSModule
             'schemas-upnp-org:service:RenderingControl:1',
             'GetVolume',
             array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
-                  'returnXml' => false)
+                  'returnXml' => true)
         );
     }
 
@@ -134,7 +134,7 @@ class PTV extends IPSModule
             'schemas-upnp-org:service:RenderingControl:1',
             'GetMute',
             array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
-                  'returnXml' => false)
+                  'returnXml' => true)
         );
     }
 

--- a/PTV/module.php
+++ b/PTV/module.php
@@ -48,7 +48,7 @@ class PTV extends IPSModule
     }
     }
 
-    public function GetValue($key)
+    public function GetValue(string $key)
     {
         return GetValue(@IPS_GetObjectIDByIdent($key, $this->InstanceID));
     }
@@ -63,14 +63,14 @@ class PTV extends IPSModule
         $this->SetState(false);
     }
 
-    public function SetState($on = true)
+    public function SetState(bool $on = true)
     {
         if ($this->GetValue('STATE') != $on) {
             $this->SendKey('NRC_POWER-ONOFF');
         }
     }
 
-    public function SendKey($keyCode)
+    public function SendKey(string $keyCode)
     {
         return $this->SoapRequest(
       'nrc/control_0',

--- a/PTV/module.php
+++ b/PTV/module.php
@@ -129,13 +129,13 @@ class PTV extends IPSModule
 
     public function GetMute()
     {
-        return (boolean) $this->SoapRequest(
+        return (boolean) ((int) $this->SoapRequest(
             'dmr/control_0',
             'schemas-upnp-org:service:RenderingControl:1',
             'GetMute',
             array('args' => '<InstanceID>0</InstanceID><Channel>Master</Channel>',
                   'returnXml' => false)
-        );
+        ));
     }
 
     public function SetMute(bool $enable)

--- a/PTVHook/module.php
+++ b/PTVHook/module.php
@@ -73,20 +73,4 @@ class PTVHook extends IPSModule
             }
         }
     }
-
-    protected function ProcessHookData()
-    {
-        $input = file_get_contents("php://input");
-        $properties = array();
-        foreach (simplexml_load_string($input)->xpath('//e:property') as $property) {
-            foreach ($property as $key => $value) {
-                $properties[(string)$key] = (string)$value;
-            }
-        }
-
-        $xml = simplexml_load_string($data)['e:propertyset'];
-        $sendData = array("DataID" => "{E8F5D5E0-5B3D-42A0-843E-28DA5ED71484}", "DeviceID" => (integer)$_GET['device_id'], "Properties" => $properties);
-        $this->SendDataToChildren(json_encode($sendData));
-        IPS_LogMessage("PTVHook", "Event");
-    }
 }

--- a/PTVHook/module.php
+++ b/PTVHook/module.php
@@ -73,4 +73,20 @@ class PTVHook extends IPSModule
             }
         }
     }
+
+    protected function ProcessHookData()
+    {
+        $input = file_get_contents("php://input");
+        $properties = array();
+        foreach (simplexml_load_string($input)->xpath('//e:property') as $property) {
+            foreach ($property as $key => $value) {
+                $properties[(string)$key] = (string)$value;
+            }
+        }
+
+        $xml = simplexml_load_string($data)['e:propertyset'];
+        $sendData = array("DataID" => "{E8F5D5E0-5B3D-42A0-843E-28DA5ED71484}", "DeviceID" => (integer)$_GET['device_id'], "Properties" => $properties);
+        $this->SendDataToChildren(json_encode($sendData));
+        IPS_LogMessage("PTVHook", "Event");
+    }
 }


### PR DESCRIPTION
- Variablentypen bei GetValue, SetState und SendKey ergänzt
- Schreibweise der Funktionsnamen vereinheitlicht (GetVolume, SetVolume, GetMute, SetMute)
- GetVolume und GetMute korrigiert